### PR TITLE
SRE-7069 update to latest image and packages version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm AS build-image
+FROM python:3.13.2-slim-bookworm AS build-image
 
 RUN apt-get update
 RUN apt-get full-upgrade -y
@@ -36,7 +36,7 @@ RUN mkdir -p /opt/oracle/instantclient
 RUN mv instantclient*/* /opt/oracle/instantclient
 
 
-FROM --platform=$BUILDPLATFORM python:3.13-slim-bookworm
+FROM --platform=$BUILDPLATFORM python:3.13.2-slim-bookworm
 ARG ODBC_DRIVER_VERSION=18
 ENV ODBC_DRIVER=msodbcsql${ODBC_DRIVER_VERSION}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,11 +25,9 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-greenlet==3.1.1
-    # via sqlalchemy
 idna==3.10
     # via yarl
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 jsonschema==4.23.0
     # via query-exporter (pyproject.toml)
@@ -39,7 +37,7 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.1.0
+multidict==6.2.0
     # via
     #   aiohttp
     #   yarl
@@ -67,7 +65,7 @@ python-dateutil==2.9.0.post0
     #   query-exporter (pyproject.toml)
 python-dotenv==1.0.1
     # via prometheus-aioexporter
-pytz==2025.1
+pytz==2025.2
     # via croniter
 pyyaml==6.0.2
     # via query-exporter (pyproject.toml)


### PR DESCRIPTION
A trivy scan indicates that:

```
leolei@C9PNW1CDPQ container-scanning-scripts % ./vulnerability-age-stats.py docker.io/adonato/query-exporter:3.2.0                                                                               [SREX-1818-improve-vulnerability-age-stats-script|…2] (cph-qa-shared/qa)
CVE Vulnerability Report:
Severity   Total      Older than 45d 
----------------------------------------
CRITICAL   0          0                   
HIGH       43         25                  
MEDIUM     168        61                  
LOW        2          2                   
UNKNOWN    0          0                   
----------------------------------------
TOTAL      213        88                  
⏲ Mar 25 19:03:14
⏲ Mar 25 19:03:14
leolei@C9PNW1CDPQ container-scanning-scripts % ./vulnerability-age-stats.py test-query-exporter                                                                                                  [SREX-1818-improve-vulnerability-age-stats-script|…2] (cph-qa-shared/qa)
CVE Vulnerability Report:
Severity   Total      Older than 45d 
----------------------------------------
CRITICAL   0          0                   
HIGH       0          0                   
MEDIUM     0          0                   
LOW        0          0                   
UNKNOWN    0          0                   
----------------------------------------
TOTAL      0          0
```

**Evidence of testing**: built the image locally and reviewed the vulnerability scan report